### PR TITLE
Fix URL for holochain-anchors dependency

### DIFF
--- a/zomes/wiki/code/Cargo.toml
+++ b/zomes/wiki/code/Cargo.toml
@@ -12,7 +12,7 @@ hdk = "=0.0.44-alpha3"
 hdk_proc_macros = "=0.0.44-alpha3"
 holochain_wasm_utils = "=0.0.44-alpha3"
 holochain_json_derive = "^0.0"
-holochain_anchors= { git = "https://github.com/eyss/holochain_anchors" }
+holochain_anchors= { git = "https://github.com/eyss/holochain-anchors" }
 holochain_roles = { git = "https://github.com/eyss/holochain_roles" }
 
 [lib]


### PR DESCRIPTION
This DNA won't compile because the GitHub URL for `holochain-anchors` has an underscore rather than a hyphen. This goes along with https://github.com/eyss/holochain_roles/pull/1.

Alternatively, eyss/holochain-anchors could be renamed to holochain_anchors so these fixes don't be made.