### PR TITLE
relative path to compiled DNA, fixed hash

### DIFF
--- a/conductor-config.toml
+++ b/conductor-config.toml
@@ -10,8 +10,8 @@ name = 'testAgent'
 public_address = 'HcSciC6UmH5duukm7cp4fJc3tbXOabvvpsvvmpeE3z5jxeoavhdwt9Vjzxekdhz'
 
 [[dnas]]
-file = '/home/hector/Escritorio/h-wiki-back/dist/h-wiki-back.dna.json'
-hash = 'QmXMkVAApazyxHvMe3tMamEnMkNwBB8dRHXc4D3bfLbtZ2'
+file = 'dist/h-wiki-back.dna.json'
+hash = 'QmT5PKN2xq5QjgsrbpmLopkpEZnwoKJnuuYrH8bpgBZEFX'
 id = 'hc-run-dna'
 
 [[instances]]


### PR DESCRIPTION
The config file had an absolute path to the compiled DNA. I changed it to a relative path, and the DNA also compiles to a different hash for me, so I updated that too. Don't know if it's just strangeness with my setup though.